### PR TITLE
Fix duplicate response in updateEvent

### DIFF
--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -42,10 +42,8 @@ export const updateEvent = async (req, res) => {
     if (result.rowCount === 0) {
         return res.status(404).send({ message: "No existe un evento con ese ID" });
     }
-    res.json(result.rows[0]);
     console.log(result);
-
-    return  res.json(result.rows[0]);
+    return res.json(result.rows[0]);
 }
 
 export const deleteEvent = async(req, res) => {


### PR DESCRIPTION
## Summary
- prevent sending multiple JSON responses in `updateEvent`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68580e6f8d008330831063e06d938904